### PR TITLE
Use the release tag_name rather than github sha for runner image build

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build and publish runner image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref }}
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Use the release tag_name to follow standard govuk release conventions.

https://github.com/alphagov/govuk-infrastructure/issues/2736